### PR TITLE
Added s3 endpoint setting to use s3 compatible providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ cloudstorage:
         bucket: mybucket
 
         # optional
+        endpoint: https://eu-central-1.amazonaws.com
         prefix: subfolder-name
         url: https://s3.eu-central-1.amazonaws.com
 ```

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -34,14 +34,17 @@ $this->on('cockpit.filestorages.init', function(&$storages) {
                     $url = "{$url}/{$settings['prefix']}";
                 }
 
-                $client = new Aws\S3\S3Client([
-                    'credentials' => [
-                        'key'    => $settings['key'],
-                        'secret' => $settings['secret']
+                $client = new Aws\S3\S3Client(array_merge(
+                    [
+                        'credentials' => [
+                            'key'    => $settings['key'],
+                            'secret' => $settings['secret']
+                        ],
+                        'region'  => $settings['region'],
+                        'version' => isset($settings['version']) ? $settings['version'] : 'latest',
                     ],
-                    'region'  => $settings['region'],
-                    'version' => isset($settings['version']) ? $settings['version'] : 'latest',
-                ]);
+                    $settings['endpoint'] ? ['endpoint' => $settings['endpoint']] : []
+                ));
 
                 $storages[$key] = [
                     'adapter' => 'League\Flysystem\AwsS3v3\AwsS3Adapter',


### PR DESCRIPTION
As mentioned in #4 added in the setting for endpoint to use other S3 providers.
Also added the setting to the readme, so others can discover the way to integrate with other s3 compatible providers more easily.